### PR TITLE
Remove edgetest bounds

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = "2021, Akshay Gupta"
 author = "Akshay Gupta"
 
 # The short X.Y version
-version = "2022.12.0"
+version = "2023.4.0"
 # The full version, including alpha/beta/rc tags
 release = ""
 

--- a/edgetest_conda/__init__.py
+++ b/edgetest_conda/__init__.py
@@ -1,6 +1,6 @@
 """Package initialization."""
 
-__version__ = "2022.12.0"
+__version__ = "2023.4.0"
 
 __title__ = "edgetest-conda"
 __description__ = "Conda edgetest plugin"

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ edgetest =
 	conda = edgetest_conda.plugin
 
 [bumpver]
-current_version = "2022.12.0"
+current_version = "2023.4.0"
 version_pattern = "YYYY.MM.INC0"
 commit_message = "Bump {old_version} to {new_version}"
 commit = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires = 
-	edgetest<=2022.11.0,>=2022.3.0
+	edgetest>=2022.3.0
 
 [options.extras_require]
 docs = 


### PR DESCRIPTION
In this PR, I am removing the upper bound on `edgetest` for the plugin. This is more in line with our other plugins. I am also bumping the version.