### PR TITLE
refactor: removing the python_version configuration option and bumping the version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = "2021, Akshay Gupta"
 author = "Akshay Gupta"
 
 # The short X.Y version
-version = "2026.1.0"
+version = "2026.4.0"
 # The full version, including alpha/beta/rc tags
 release = ""
 

--- a/edgetest_conda/__init__.py
+++ b/edgetest_conda/__init__.py
@@ -1,6 +1,6 @@
 """Package initialization."""
 
-__version__ = "2026.1.0"
+__version__ = "2026.4.0"
 
 __title__ = "edgetest-conda"
 __description__ = "Conda edgetest plugin"

--- a/edgetest_conda/plugin.py
+++ b/edgetest_conda/plugin.py
@@ -38,9 +38,6 @@ def addoption(schema: Schema):
         },
     )
     schema.add_envoption(
-        "python_version", {"type": "string", "default": "3.10", "coerce": str}
-    )
-    schema.add_envoption(
         "update_with_conda",
         {
             "type": "boolean",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,19 @@ cerberus==1.3.8
     # via edgetest
 click==8.3.1
     # via edgetest
-edgetest==2026.1.1
+edgetest==2026.4.0
     # via edgetest-conda (setup.cfg)
 packaging==26.0
     # via edgetest
 pluggy==1.6.0
     # via edgetest
-pyproject-fmt==2.11.1
+pyproject-fmt==2.16.0
     # via edgetest
 tabulate==0.9.0
     # via edgetest
-toml-fmt-common==1.1.0
+toml-fmt-common==1.3.2
     # via pyproject-fmt
 tomlkit==0.14.0
     # via edgetest
-uv==0.9.26
+uv==0.10.2
     # via edgetest

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 install_requires =
-	edgetest>=2022.3.0
+	edgetest>=2026.4.0
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ edgetest =
 	conda = edgetest_conda.plugin
 
 [bumpver]
-current_version = "2026.1.0"
+current_version = "2026.4.0"
 version_pattern = "YYYY.MM.INC0"
 commit_message = "Bump {old_version} to {new_version}"
 commit = True


### PR DESCRIPTION
In this PR, I've removed the custom `python_version` field since it was added in edgetest 2026.4.0. I have also bumped the version of this library in preparation for a release.